### PR TITLE
fix bug where TUN devices are opened without IFF_NO_PI flag

### DIFF
--- a/components/gpp/stack/TunTap/TunTapComponent.cpp
+++ b/components/gpp/stack/TunTap/TunTapComponent.cpp
@@ -127,7 +127,7 @@ void TunTapComponent::start()
 
   // Connect to the device
   strcpy(tunName_, tunTapDevice_x.c_str());
-  int flags = strstr(tunName_, "tap") == NULL ? IFF_TUN : IFF_TAP | IFF_NO_PI;
+  int flags = strstr(tunName_, "tap") == NULL ? IFF_TUN | IFF_NO_PI : IFF_TAP | IFF_NO_PI;
   if ((tunFd_ = allocateTunDevice(tunName_, flags)) >= 0)
   {
     LOG(LINFO) << "Successfully attached to tun/tap device "


### PR DESCRIPTION
The purpose of the IFF_NO_PI flag is to tell the networking stack
to pass all packets without any additional information. If this
is not set, the kernel appends 4 extra bytes to each packet.
